### PR TITLE
Use disconnect to make db healtcheck interruptable

### DIFF
--- a/scala-zio-example/src/main/scala/org/organization/db/repository/HealthCheckHelper.scala
+++ b/scala-zio-example/src/main/scala/org/organization/db/repository/HealthCheckHelper.scala
@@ -26,6 +26,6 @@ trait HealthCheckHelper {
       *
       * Quadratisch. Praktisch. Gut.
       */
-    run(q).unit.forkDaemon.flatMap(_.join)
+    run(q).unit.disconnect
   }
 }


### PR DESCRIPTION
Change fork-join trick to built-in method. 

Note: after upgrade to ZIO 2 timeout will work without this trick, due to `race` auto-disconnecting it's children. 
But this behavior will be changed: 
https://github.com/zio/zio/pull/7761
Seems like explicitly adding `disconnect` in such cases is idiomatic way to go. 