### PR TITLE
Add organize imports plugin

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -37,4 +37,4 @@ jobs:
       uses: olafurpg/setup-scala@v13
 
     - name: Compile, check formatting, lint, and run tests
-      run: sbt compile scalafmtCheck "scalafixAll --check" test
+      run: sbt compile styleCheck test

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,4 +1,5 @@
 rules = [
+  OrganizeImports
   DisableSyntax,
   NoValInForComprehension,
   ProcedureSyntax,
@@ -22,3 +23,20 @@ DisableSyntax.noUniversalEquality = true
 triggered.rules = [
   DisableSyntax
 ]
+
+OrganizeImports {
+  blankLines = Auto
+  coalesceToWildcardImportThreshold = null
+  expandRelative = true
+  groupExplicitlyImportedImplicitsSeparately = false
+  groupedImports = AggressiveMerge
+  groups = [
+    "re:javax?\\."
+    "scala."
+    "*"
+  ]
+  importSelectorsOrder = Ascii
+  importsOrder = Ascii
+  preset = DEFAULT
+  removeUnused = true
+}

--- a/aliases.sbt
+++ b/aliases.sbt
@@ -1,0 +1,8 @@
+addCommandAlias(
+  "styleCheck",
+  "scalafmtSbtCheck; scalafmtCheckAll; scalafixAll --check"
+)
+addCommandAlias(
+  "styleFix",
+  "scalafixAll; scalafmtSbt; scalafmtAll"
+)

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ ThisBuild / organization := "org.organization"
 ThisBuild / scalaVersion := "2.13.10"
 ThisBuild / version      := "0.1.1-SNAPSHOT"
 
+Global / onChangedBuildSource := ReloadOnSourceChanges
+
 lazy val scalaZioExample = (project in file("scala-zio-example"))
   .settings(
     settings
@@ -40,11 +42,6 @@ lazy val settings = Seq(
     "-Ywarn-value-discard",    // Warn when non-Unit expression results are unused.
     "-Werror"                  // Fail the compilation if there are any warnings.
   ),
-
-  // Scalafix
-  semanticdbEnabled := true,                        // Enable SemanticDB
-  semanticdbVersion := scalafixSemanticdb.revision, // Only required for Scala 2.x
-  scalafixOnCompile := true, // Run scalafix every time on compile. Comment out when necessary
 
   testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
 )

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,6 @@ lazy val settings = Seq(
     "-Ywarn-value-discard",    // Warn when non-Unit expression results are unused.
     "-Werror"                  // Fail the compilation if there are any warnings.
   ),
-
   testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
 )
 

--- a/scala-zio-example/src/main/scala/org/organization/AppEnv.scala
+++ b/scala-zio-example/src/main/scala/org/organization/AppEnv.scala
@@ -1,12 +1,12 @@
 package org.organization
 
+import javax.sql.DataSource
+
 import io.getquill.jdbczio.Quill
 import org.organization.config.HttpServerConfig
 import zio.Console.printLine
 import zio._
 import zio.http.Server
-
-import javax.sql.DataSource
 
 object AppEnv {
   type AppEnv = DataSource with Server

--- a/scala-zio-example/src/main/scala/org/organization/Application.scala
+++ b/scala-zio-example/src/main/scala/org/organization/Application.scala
@@ -1,11 +1,11 @@
 package org.organization
 
+import java.io.IOException
+
 import org.organization.AppEnv.AppEnv
 import org.organization.http.AppServer
 import org.organization.utils.db.Migration
 import zio.{ZIOAppDefault, _}
-
-import java.io.IOException
 
 object Application extends ZIOAppDefault {
   private val main: ZIO[AppEnv, Throwable, Nothing] = (

--- a/scala-zio-example/src/main/scala/org/organization/api/model/NewType.scala
+++ b/scala-zio-example/src/main/scala/org/organization/api/model/NewType.scala
@@ -1,10 +1,10 @@
 package org.organization.api.model
 
+import java.util.UUID
+
 import io.circe.{Decoder, Encoder}
 import io.estatico.newtype.macros.newtype
 import io.estatico.newtype.ops.toCoercibleIdOps
-
-import java.util.UUID
 
 object NewType {
 

--- a/scala-zio-example/src/main/scala/org/organization/api/to/NewPersonTO.scala
+++ b/scala-zio-example/src/main/scala/org/organization/api/to/NewPersonTO.scala
@@ -1,9 +1,9 @@
 package org.organization.api.to
 
+import java.time.Instant
+
 import io.scalaland.chimney.dsl.TransformerOps
 import org.organization.db.model.{Gender, NewPersonData}
-
-import java.time.Instant
 
 final case class NewPersonTO(name: String, birthDate: Instant, gender: Gender) {
   def toDomain: NewPersonData =

--- a/scala-zio-example/src/main/scala/org/organization/api/to/PersonTO.scala
+++ b/scala-zio-example/src/main/scala/org/organization/api/to/PersonTO.scala
@@ -1,9 +1,9 @@
 package org.organization.api.to
 
+import java.time.Instant
+
 import org.organization.api.model.NewType.PersonIdentifier
 import org.organization.db.model.Gender
-
-import java.time.Instant
 
 final case class PersonTO(
     identifier: PersonIdentifier,

--- a/scala-zio-example/src/main/scala/org/organization/db/model/PersonEnt.scala
+++ b/scala-zio-example/src/main/scala/org/organization/db/model/PersonEnt.scala
@@ -1,10 +1,10 @@
 package org.organization.db.model
 
+import java.time.Instant
+
 import io.scalaland.chimney.dsl.TransformerOps
 import org.organization.api.model.NewType.PersonIdentifier
 import org.organization.api.to.PersonTO
-
-import java.time.Instant
 
 final case class PersonEnt(
     id: Long,

--- a/scala-zio-example/src/main/scala/org/organization/db/repository/HealthCheckHelper.scala
+++ b/scala-zio-example/src/main/scala/org/organization/db/repository/HealthCheckHelper.scala
@@ -1,10 +1,10 @@
 package org.organization.db.repository
 
+import javax.sql.DataSource
+
 import org.organization.AppEnv.AppRIO
 import org.organization.db.DbContext._
 import org.organization.db.DbContext.ctx._
-
-import javax.sql.DataSource
 
 trait HealthCheckHelper {
 

--- a/scala-zio-example/src/main/scala/org/organization/db/repository/PersonRepository.scala
+++ b/scala-zio-example/src/main/scala/org/organization/db/repository/PersonRepository.scala
@@ -1,14 +1,14 @@
 package org.organization.db.repository
 
+import java.util.UUID
+import javax.sql.DataSource
+
 import io.scalaland.chimney.dsl.TransformerOps
 import org.organization.AppEnv.AppRIO
 import org.organization.api.model.NewType.PersonIdentifier
 import org.organization.db.DbContext._
 import org.organization.db.DbContext.ctx._
 import org.organization.db.model.{NewPersonData, PersonEnt}
-
-import java.util.UUID
-import javax.sql.DataSource
 
 trait PersonRepository {
 

--- a/scala-zio-example/src/main/scala/org/organization/utils/DemoData.scala
+++ b/scala-zio-example/src/main/scala/org/organization/utils/DemoData.scala
@@ -1,11 +1,11 @@
 package org.organization.utils
 
+import java.time.Instant
+import javax.sql.DataSource
+
 import org.organization.AppEnv.AppRIO
 import org.organization.db.model.{Gender, NewPersonData}
 import org.organization.db.repository.PersonRepository
-
-import java.time.Instant
-import javax.sql.DataSource
 
 object DemoData extends PersonRepository {
 

--- a/scala-zio-example/src/main/scala/org/organization/utils/DemoDb.scala
+++ b/scala-zio-example/src/main/scala/org/organization/utils/DemoDb.scala
@@ -1,10 +1,10 @@
 package org.organization.utils
 
+import java.io.IOException
+
 import org.organization.AppEnv
 import org.organization.utils.db.Migration
 import zio.{ZIOAppDefault, _}
-
-import java.io.IOException
 
 // Executable feature to fill db by demo data
 object DemoDb extends ZIOAppDefault {

--- a/scala-zio-example/src/main/scala/org/organization/utils/db/Migration.scala
+++ b/scala-zio-example/src/main/scala/org/organization/utils/db/Migration.scala
@@ -1,10 +1,10 @@
 package org.organization.utils.db
 
+import javax.sql.DataSource
+
 import org.flywaydb.core.Flyway
 import org.organization.AppEnv.AppRIO
 import zio._
-
-import javax.sql.DataSource
 
 object Migration {
   def migrate: AppRIO[DataSource, Unit] = for {

--- a/scala-zio-example/src/test/scala/org/organization/integration_tests/HealthCheckHelperSpec.scala
+++ b/scala-zio-example/src/test/scala/org/organization/integration_tests/HealthCheckHelperSpec.scala
@@ -1,10 +1,10 @@
 package org.organization.integration_tests
 
+import javax.sql.DataSource
+
 import org.organization.db.repository.HealthCheckHelper
 import org.organization.integration_tests.util.DatabaseIntegrationSpec
 import zio.test._
-
-import javax.sql.DataSource
 
 object HealthCheckHelperSpec extends DatabaseIntegrationSpec with HealthCheckHelper {
 

--- a/scala-zio-example/src/test/scala/org/organization/integration_tests/PersonRepositorySpec.scala
+++ b/scala-zio-example/src/test/scala/org/organization/integration_tests/PersonRepositorySpec.scala
@@ -1,14 +1,14 @@
 package org.organization.integration_tests
 
+import java.time.Instant
+import javax.sql.DataSource
+
 import org.organization.db.model.Gender.{Female, Male, NonBinary}
 import org.organization.db.model.NewPersonData
 import org.organization.db.repository.PersonRepository
 import org.organization.integration_tests.util.DatabaseIntegrationSpec
 import zio.test.Assertion.equalTo
 import zio.test._
-
-import java.time.Instant
-import javax.sql.DataSource
 
 object PersonRepositorySpec extends DatabaseIntegrationSpec with PersonRepository {
 

--- a/scala-zio-example/src/test/scala/org/organization/integration_tests/util/DatabaseIntegrationSpec.scala
+++ b/scala-zio-example/src/test/scala/org/organization/integration_tests/util/DatabaseIntegrationSpec.scala
@@ -1,13 +1,13 @@
 package org.organization.integration_tests.util
 
+import javax.sql.DataSource
+
 import com.dimafeng.testcontainers.MySQLContainer
 import io.github.scottweaver.zio.aspect.DbMigrationAspect
 import io.github.scottweaver.zio.testcontainers.mysql.ZMySQLContainer
 import io.github.scottweaver.zio.testcontainers.mysql.ZMySQLContainer.Settings
 import zio._
 import zio.test.{ZIOSpecDefault, _}
-
-import javax.sql.DataSource
 
 /** Spins up a separate MySQL container for each test. Limits the number of tests running in
   * parallel to put an upper bound on resource usage

--- a/scalafix.sbt
+++ b/scalafix.sbt
@@ -1,0 +1,6 @@
+ThisBuild / scalafixScalaBinaryVersion := scalaBinaryVersion.value
+ThisBuild / scalafixDependencies ++= Seq(
+  "com.github.liancheng" %% "organize-imports" % "0.6.0"
+)
+ThisBuild / semanticdbEnabled := true
+ThisBuild / semanticdbVersion := scalafixSemanticdb.revision


### PR DESCRIPTION
- adds organize import plugin to format imports in unified way (vscode, idea)
- adds two aliases - styleCheck, styleFix to check/apply formatting
- moves scalafix settings to project level (or aliases don't work on root project)

Changes: 
https://github.com/SwiftInvention/scala-zio-example/pull/41/commits/808bb3530fe74871353beea2defc8d19bf7726b6

Formatting: 
https://github.com/SwiftInvention/scala-zio-example/pull/41/commits/9289b2897db6f797b363e1de1302ad4da895afba