### PR TITLE
Add sbt tpolecat plugin

### DIFF
--- a/aliases.sbt
+++ b/aliases.sbt
@@ -1,0 +1,8 @@
+addCommandAlias(
+  "dev",
+  "tpolecatDevMode",
+)
+addCommandAlias(
+  "ci",
+  "tpolecatCiMode",
+)

--- a/build.sbt
+++ b/build.sbt
@@ -17,30 +17,7 @@ lazy val scalaZioExampleRoot = project
 
 lazy val settings = Seq(
   libraryDependencies ++= commonDep ++ testDep ++ httpDep ++ dbDep,
-  scalacOptions ++= Seq(
-    "-deprecation", // Emit warning and location for usages of deprecated APIs.
-    "-encoding",
-    "utf-8",         // Specify character encoding used by source files.
-    "-explaintypes", // Explain type errors in more detail.
-    "-feature", // Emit warning and location for usages of features that should be imported explicitly.
-    "-language:higherKinds",         // Allow higher-kinded types
-    "-language:postfixOps",          // Allow postfix operator notation, such as 1 to 10 toList
-    "-language:implicitConversions", // Allow definition of implicit functions called views
-    "-unchecked",       // Enable additional warnings where generated code depends on assumptions.
-    "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
-    "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
-    "-Ymacro-annotations", // Allow to use macro annotations which is needed in elastico/newtypes
-    "-Ywarn-dead-code",    // Warn when dead code is identified.
-    "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
-    "-Ywarn-unused:imports",   // Warn if an import selector is not referenced.
-    "-Ywarn-unused:locals",    // Warn if a local definition is unused.
-    "-Ywarn-unused:params",    // Warn if a value parameter is unused.
-    "-Ywarn-unused:patvars",   // Warn if a variable bound in a pattern is unused.
-    "-Ywarn-unused:privates",  // Warn if a private member is unused.
-    "-Ywarn-value-discard",    // Warn when non-Unit expression results are unused.
-    "-Werror"                  // Fail the compilation if there are any warnings.
-  ),
-
+  tpolecatScalacOptions += ScalacOptions.other("-Ymacro-annotations"),
   // Scalafix
   semanticdbEnabled := true,                        // Enable SemanticDB
   semanticdbVersion := scalafixSemanticdb.revision, // Only required for Scala 2.x

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,13 @@
 val sbtScalafmt      = "2.5.0"
 val sbtScalafix      = "0.10.4"
+val sbtTpolecat      = "0.4.2"
 val kindProjector    = "0.13.2"
 val betterMonadicFor = "0.3.1"
 
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"       % sbtScalafmt)
 addSbtPlugin("ch.epfl.scala"      % "sbt-scalafix"       % sbtScalafix)
 addSbtPlugin("io.spray"           % "sbt-revolver"       % "0.9.1")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"  % sbtTpolecat)
 addCompilerPlugin("org.typelevel" % "kind-projector"     % kindProjector cross CrossVersion.full)
 addCompilerPlugin("com.olegpy"   %% "better-monadic-for" % betterMonadicFor)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 val sbtScalafmt      = "2.5.0"
 val sbtScalafix      = "0.10.4"
 val sbtTpolecat      = "0.4.2"
+val sbtRewarn        = "0.1.3"
 val kindProjector    = "0.13.2"
 val betterMonadicFor = "0.3.1"
 
@@ -8,6 +9,7 @@ addSbtPlugin("org.scalameta"      % "sbt-scalafmt"       % sbtScalafmt)
 addSbtPlugin("ch.epfl.scala"      % "sbt-scalafix"       % sbtScalafix)
 addSbtPlugin("io.spray"           % "sbt-revolver"       % "0.9.1")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"  % sbtTpolecat)
+addSbtPlugin("com.timushev.sbt"          % "sbt-rewarn"    % sbtRewarn)
 addCompilerPlugin("org.typelevel" % "kind-projector"     % kindProjector cross CrossVersion.full)
 addCompilerPlugin("com.olegpy"   %% "better-monadic-for" % betterMonadicFor)
 


### PR DESCRIPTION
Adds 
https://github.com/typelevel/sbt-tpolecat

- tpolecat's compiler options are applied by default
- use `dev`/`ci` to switch between dev mode and ci mode to temporary disable warnings as errors
- add sbt-rewarn plugin, so that in dev mode sbt won't hide warnings on second compilation