### PR TITLE
Update dependency versions

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,4 +1,7 @@
 # every Monday on midnight
 pullRequests.frequency = "0 0 ? * MON"
 
-updates.ignore = []
+updates.ignore = [
+  { groupId = "org.slf4j" },
+  { groupId = "com.beachape" }  # enumeratum
+]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,11 +4,10 @@ import sbt.librarymanagement.InclExclRule
 object Dependencies {
 
   lazy val commonDep: Seq[ModuleID] = Seq(
-    "dev.zio"                     %% "zio"           % Versions.zio,
-    "com.github.pureconfig"       %% "pureconfig"    % Versions.pureConfig,
-    "io.scalaland"                %% "chimney"       % Versions.chimney,
-    "io.estatico"                 %% "newtype"       % Versions.newType,
-    "com.softwaremill.sttp.tapir" %% "tapir-newtype" % Versions.tapir
+    "dev.zio"               %% "zio"        % Versions.zio,
+    "com.github.pureconfig" %% "pureconfig" % Versions.pureConfig,
+    "io.scalaland"          %% "chimney"    % Versions.chimney,
+    "io.estatico"           %% "newtype"    % Versions.newType
   ) map (_ % Compile)
 
   lazy val dbDep: Seq[ModuleID] = Seq(
@@ -24,12 +23,13 @@ object Dependencies {
   ) map (_ % Compile)
 
   lazy val httpDep: Seq[ModuleID] = Seq(
+    "dev.zio"                     %% "zio-http"                % Versions.zioHttp,
     "com.softwaremill.sttp.tapir" %% "tapir-core"              % Versions.tapir,
     "com.softwaremill.sttp.tapir" %% "tapir-json-circe"        % Versions.tapir,
     "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs"      % Versions.tapir,
     "com.softwaremill.sttp.tapir" %% "tapir-zio-http-server"   % Versions.tapir,
     "com.softwaremill.sttp.tapir" %% "tapir-swagger-ui-bundle" % Versions.tapir,
-    "dev.zio"                     %% "zio-http"                % Versions.zioHttp
+    "com.softwaremill.sttp.tapir" %% "tapir-newtype"           % Versions.tapir
   ) map (_ % Compile)
 
   lazy val logDep: Seq[ModuleID] = Seq(

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,17 +1,17 @@
 object Versions {
-  val flyway            = "9.14.1"
+  val flyway            = "9.15.0"
   val mysql             = "8.0.32"
   val quill             = "4.6.0"
-  val tapir             = "1.2.6"
-  val zio               = "2.0.6"
+  val tapir             = "1.2.9"
+  val zio               = "2.0.9"
   val pureConfig        = "0.17.2"
-  val zioHttp           = "0.0.3"
-  val zioTestContainers = "0.9.0"
+  val zioHttp           = "0.0.4"
+  val zioTestContainers = "0.10.0"
   val chimney           = "0.6.2"
   val enumeratum =
     "1.7.0" // Note: Versions above 1.7.0 add Scala 3 support and are not binary compatible with previous versions
   val newType    = "0.4.4"
-  val zioLogging = "2.1.8"
-  val slf4j      = "1.7.36"
+  val zioLogging = "2.1.9"
+  val slf4j      = "1.7.36" // We keep version 1.7.36 because it's used by quill
   val circe      = "0.14.3"
 }

--- a/scala-zio-example/src/main/scala/org/organization/AppEnv.scala
+++ b/scala-zio-example/src/main/scala/org/organization/AppEnv.scala
@@ -24,7 +24,7 @@ object AppEnv {
     ZLayer {
       ZIO
         .attempt(LoadConfig("mysql"))
-        .map(JdbcContextConfig(_))
+        .map(JdbcContextConfig)
         .tap(cfg => ZIO.attempt(new HikariConfig(cfg.configProperties).validate()))
     }
 

--- a/scala-zio-example/src/main/scala/org/organization/AppLog.scala
+++ b/scala-zio-example/src/main/scala/org/organization/AppLog.scala
@@ -6,7 +6,7 @@ import zio.{LogLevel, TaskLayer}
 
 object AppLog {
   private val loggerName =
-    LoggerNameExtractor.annotationOrTrace(Slf4jBridge.loggerNameAnnotationKey)
+    LoggerNameExtractor.annotationOrTrace(zio.logging.loggerNameAnnotationKey)
 
   private val logFormat =
     LogFormat.label("name", loggerName.toLogFormat()) + LogFormat.default

--- a/scala-zio-example/src/main/scala/org/organization/http/AppServer.scala
+++ b/scala-zio-example/src/main/scala/org/organization/http/AppServer.scala
@@ -4,20 +4,22 @@ import org.organization.AppEnv.AppEnv
 import org.organization.http.swagger.SwaggerApiEndpoint
 import sttp.tapir.server.ziohttp.ZioHttpInterpreter
 import zio.http._
-import zio.http.middleware.HttpMiddleware
 import zio.{Duration, RIO, ZIO}
 
 object AppServer {
 
-  private val composedMiddlewares: HttpMiddleware[Any, Throwable] =
+  private val composedMiddlewares: HttpAppMiddleware[Any, Throwable] =
     Middleware.timeout(Duration.fromSeconds(10))
 
   private val httpInterpreter =
     ZioHttpInterpreter().toHttp(SwaggerApiEndpoint.common)
 
-  private val app: Http[AppEnv, Throwable, Request, Response] =
+  private val app =
     httpInterpreter @@ composedMiddlewares
 
   def serve: RIO[AppEnv, Nothing] =
-    Server.install(app).flatMap(p => ZIO.logInfo(s"Started server on port $p") *> ZIO.never)
+    Server
+      .install(app.withDefaultErrorResponse)
+      .flatMap(p => ZIO.logInfo(s"Started server on port $p"))
+      .zipRight(ZIO.never)
 }

--- a/scala-zio-example/src/test/scala/org/organization/integration_tests/util/DatabaseIntegrationSpec.scala
+++ b/scala-zio-example/src/test/scala/org/organization/integration_tests/util/DatabaseIntegrationSpec.scala
@@ -3,6 +3,7 @@ package org.organization.integration_tests.util
 import javax.sql.DataSource
 
 import com.dimafeng.testcontainers.MySQLContainer
+import io.github.scottweaver.models.JdbcInfo
 import io.github.scottweaver.zio.aspect.DbMigrationAspect
 import io.github.scottweaver.zio.testcontainers.mysql.ZMySQLContainer
 import io.github.scottweaver.zio.testcontainers.mysql.ZMySQLContainer.Settings
@@ -19,14 +20,15 @@ abstract class DatabaseIntegrationSpec extends ZIOSpecDefault {
   val mysqlVersion     = "8.0"
   val parallelismLimit = 4
 
-  private val containerLayer = ZLayer.succeed(
-    Settings(
-      mysqlVersion,
-      MySQLContainer.defaultDatabaseName,
-      MySQLContainer.defaultUsername,
-      MySQLContainer.defaultPassword
-    )
-  ) >+> ZMySQLContainer.live
+  private val containerLayer: ULayer[DataSource with JdbcInfo] =
+    ZLayer.succeed(
+      Settings(
+        mysqlVersion,
+        MySQLContainer.defaultDatabaseName,
+        MySQLContainer.defaultUsername,
+        MySQLContainer.defaultPassword
+      )
+    ) >+> ZMySQLContainer.live
 
   final def spec: Spec[TestEnvironment, Any] =
     (integrationSpec


### PR DESCRIPTION
* Bump zio-http and tapir versions, fix breaks caused by api changes
* Bump other dependencies
* Make scala-steward ignore updates for slf4j and enumeratum